### PR TITLE
Stats memory cleanup for Iterator

### DIFF
--- a/lama/common.py
+++ b/lama/common.py
@@ -237,7 +237,7 @@ def write_array(array: np.ndarray, path: Union[str, Path], compressed=True, ras=
     img = sitk.GetImageFromArray(array)
     if ras:
         img.SetDirection((-1, 0, 0, 0, -1, 0, 0, 0, 1))
-    sitk.WriteImage(sitk.GetImageFromArray(array), path, compressed)
+    sitk.WriteImage(img, path, compressed)
 
 
 def read_array( path: Union[str, Path]):
@@ -946,3 +946,21 @@ def cfg_load(cfg) -> Dict:
 
     else:
         raise ValueError('Config file should end in .toml or .yaml')
+
+
+def bytesToGb(numberOfBytes, precision = 3):
+    return round(numberOfBytes / (1024 ** 3), precision)
+    
+def logMemoryUsageInfo():
+    proc = psutil.Process(os.getpid())
+    
+    procMemInfo = proc.memory_info()
+    globalMemInfo = psutil.virtual_memory()
+
+    totalMem = bytesToGb(globalMemInfo.total, 5)
+    totalMemAvailable = bytesToGb(globalMemInfo.available, 5)
+    procMemRSS = bytesToGb(procMemInfo.rss, 5)
+    procMemVMS = bytesToGb(procMemInfo.vms, 5)
+    procMemData = bytesToGb(procMemInfo.data, 5)
+    
+    logging.info(f"Memory: Process Resident: {procMemRSS}, Process Virtual: {procMemVMS}, Process data: {procMemData}.  Total Available: {totalMemAvailable}")

--- a/lama/stats/standard_stats/data_loaders.py
+++ b/lama/stats/standard_stats/data_loaders.py
@@ -34,6 +34,10 @@ from lama import common
 from lama.img_processing.misc import blur
 from lama.paths import specimen_iterator
 
+import os
+import gc
+import sys
+import psutil
 
 GLCM_FILE_SUFFIX = '.npz'
 DEFAULT_FWHM = 100  # um
@@ -91,6 +95,8 @@ class LineData:
         self.size = np.prod(shape)
         self.mask = mask
 
+        logging.info(f"Create line data '{self.line}'")
+
         if len(data) != len(info):
             raise ValueError
 
@@ -127,23 +133,14 @@ class LineData:
         overhead_factor = 100
         # debug
         bytes_free = common.available_memory()
-        num_samples = len(self.data)
+        procMemRSS_bytes = psutil.Process(os.getpid()).memory_info().rss
 
-        try:
-            self.data.shape
-        except AttributeError:  # List of numpy arrays
-            dtype_size = self.data[0].dtype.itemsize
-            num_voxels = self.data[0].size
-        else:  # Dataframes
-            num_voxels = self.data.shape[1]
-            dtype_size = self.data.values.dtype.itemsize
-
-        data_size = dtype_size * num_samples * num_voxels
-
-        num_chunks = math.ceil((data_size * overhead_factor) / bytes_free)
+        num_chunks = math.ceil((procMemRSS_bytes * overhead_factor) / bytes_free)
 
         if log:
-            logging.info(f'\nAvailable memory: {round(bytes_free / (1024 **3), 3)} GB\nSize of raw data: {round(data_size / (1024**3), 3)} GB')
+            logging.info(f'\nAvailable memory: {common.bytesToGb(bytes_free)} GB\nProcess memory: {common.bytesToGb(procMemRSS_bytes)} GB')
+
+
 
         if num_chunks > 1:
             return num_chunks
@@ -190,6 +187,35 @@ class LineData:
     @property  # delete
     def mask_size(self) -> int:
         return self.mask[self.mask == 1].size
+
+    def cleanup(self):
+        logging.info(f"Cleanup line data '{self.line}', object size {sys.getsizeof(self)} byte.")
+        
+        if self.data is not None:
+            self.data = None
+        
+        if self.shape is not None: 
+            self.shape = None
+        
+        if self.info is not None: 
+            self.info = None
+        
+        if self.paths is not None: 
+            self.paths = None
+        
+        if self.outdirs is not None: 
+            self.outdirs = None
+        
+        if self.size is not None: 
+            self.size = None
+        
+        if self.mask is not None: 
+            self.mask = None
+        
+        gc.collect()
+        
+    def __del__(self):
+        logging.info(f"Finalize line data '{self.line}'")
 
 
 class DataLoader:

--- a/lama/stats/standard_stats/lama_stats_new.py
+++ b/lama/stats/standard_stats/lama_stats_new.py
@@ -16,6 +16,8 @@ from typing import Union, List
 from logzero import logger as logging
 import logzero
 
+import gc
+
 from lama.common import cfg_load
 from lama.stats.standard_stats.stats_objects import Stats
 from lama.stats.standard_stats.data_loaders import DataLoader, load_mask, LineData
@@ -81,7 +83,7 @@ def run(config_path: Path,
     label_map_file = target_dir / stats_config.get('label_map')
     label_map = common.LoadImage(label_map_file).array
 
-    memmap = stats_config.get('label_map')
+    memmap = stats_config.get('memmap')
     if memmap:
         logging.info('Memory mapping input data')
 
@@ -97,7 +99,10 @@ def run(config_path: Path,
     for stats_type in stats_config['stats_types']:
 
         logzero.logfile(str(master_log_file))
-        logging.info(f"Doing {stats_type} analysis")
+        logging.info(f"---Doing {stats_type} analysis---")
+        
+        gc.collect()
+        
         # load the required stats object and data loader
         loader_class = DataLoader.factory(stats_type)
 
@@ -110,45 +115,73 @@ def run(config_path: Path,
         # Currently only the intensity stats get normalised
         loader.normaliser = Normaliser.factory(stats_config.get('normalise'), stats_type)  # move this into subclass
 
-        for line_input_data in loader.line_iterator():  # NOTE: This might be where we could parallelize
-
-            line_id = line_input_data.line
-
-            line_stats_out_dir = out_dir / line_id / stats_type
-
-            line_stats_out_dir.mkdir(parents=True, exist_ok=True)
-            line_log_file = line_stats_out_dir / f'{common.date_dhm()}_stats.log'
-            logzero.logfile(str(line_log_file))
-
-            logging.info(f"Processing line: {line_id}")
-
-            stats_class = Stats.factory(stats_type)
-            stats_obj = stats_class(line_input_data, stats_type, stats_config.get('use_staging', True))
-
-            stats_obj.stats_runner = linear_model.lm_r
-            stats_obj.run_stats()
-
-            logging.info('statistical analysis finished. Writing results.')
-
-            rw = ResultsWriter.factory(stats_type)
-            writer = rw(stats_obj, mask, line_stats_out_dir, stats_type, label_map, label_info_file)
-
-            #
-            # if stats_type == 'organ_volumes':
-            #     c_data = {spec: data['t'] for spec, data in stats_obj.specimen_results.items()}
-            #     c_df = pd.DataFrame.from_dict(c_data)
-            #     # cluster_plots.tsne_on_raw_data(c_df, line_stats_out_dir)
-
-            if stats_config.get('invert_stats'):
-                if writer.line_heatmap:  # Organ vols wil not have this
-                    # How do I now sensibily get the path to the invert.yaml
-                    # get the invert_configs for each specimen in the line
-                    logging.info('Propogating the heatmaps back onto the input images ')
-                    line_heatmap = writer.line_heatmap
-                    line_reg_dir = mut_dir / 'output' / line_id
-                    invert_heatmaps(line_heatmap, line_stats_out_dir, line_reg_dir, line_input_data)
-
-            logging.info('All done')
+        logging.info("Start iterate through lines")
+        common.logMemoryUsageInfo()
+  
+        line_iterator = loader.line_iterator()
+        line_input_data = None
+ 
+        while True:
+            try:
+                line_input_data = next(line_iterator)
+                logging.info(f"Data for line {line_input_data.line} loaded")
+                common.logMemoryUsageInfo()
+         
+      
+                line_id = line_input_data.line
+      
+                line_stats_out_dir = out_dir / line_id / stats_type
+      
+                line_stats_out_dir.mkdir(parents=True, exist_ok=True)
+                line_log_file = line_stats_out_dir / f'{common.date_dhm()}_stats.log'
+                logzero.logfile(str(line_log_file))
+      
+                logging.info(f"Processing line: {line_id}")
+      
+                stats_class = Stats.factory(stats_type)
+                stats_obj = stats_class(line_input_data, stats_type, stats_config.get('use_staging', True))
+      
+                stats_obj.stats_runner = linear_model.lm_r
+                stats_obj.run_stats()
+      
+                logging.info('Statistical analysis finished.')
+                common.logMemoryUsageInfo()
+                
+                logging.info('Writing results...')
+                
+                rw = ResultsWriter.factory(stats_type)
+                writer = rw(stats_obj, mask, line_stats_out_dir, stats_type, label_map, label_info_file)
+                
+                logging.info('Finished writing results.')
+                common.logMemoryUsageInfo()
+                #
+                # if stats_type == 'organ_volumes':
+                #     c_data = {spec: data['t'] for spec, data in stats_obj.specimen_results.items()}
+                #     c_df = pd.DataFrame.from_dict(c_data)
+                #     # cluster_plots.tsne_on_raw_data(c_df, line_stats_out_dir)
+ 
+      
+                if stats_config.get('invert_stats'):
+                    if writer.line_heatmap:  # Organ vols wil not have this
+                        # How do I now sensibily get the path to the invert.yaml
+                        # get the invert_configs for each specimen in the line
+                        logging.info('Writing heatmaps...')
+                        logging.info('Propogating the heatmaps back onto the input images ')
+                        line_heatmap = writer.line_heatmap
+                        line_reg_dir = mut_dir / 'output' / line_id
+                        invert_heatmaps(line_heatmap, line_stats_out_dir, line_reg_dir, line_input_data)
+                        logging.info('Finished writing heatmaps.')
+ 
+                logging.info(f"Finished processing line: {line_id} - All done")                  
+                common.logMemoryUsageInfo()
+                               
+            except StopIteration:
+                if (line_input_data != None):
+                    logging.info(f"Finish iterate through lines")
+                    line_input_data.cleanup()
+                    common.logMemoryUsageInfo()
+                break;            
+         
 
 
 def invert_heatmaps(heatmap: Path,

--- a/lama/stats/standard_stats/results_writer.py
+++ b/lama/stats/standard_stats/results_writer.py
@@ -73,15 +73,20 @@ class ResultsWriter:
         line_qvals = results.line_qvals
         line_pvals = results.line_pvalues # Need to get thse into organ volumes
 
+        logging.info('Writing line-level results...')
+        
         line_threshold_file = self.out_dir / f'Qvals_{stats_name}_{self.line}.csv'
         write_threshold_file(line_qvals, line_tstats, line_threshold_file)
 
         # this is for the lama_stats to know where the heatmaps for inversion are
         self.line_heatmap = self._write(line_tstats, line_pvals, line_qvals, self.out_dir, self.line)  # Bodge. Change!
         # 140620: I think this is where it's dying
-        print('#finished Writing line results')
         # pvalue_fdr_plot(results.line_pvalues, results.line_qvals, out_dir)
 
+        logging.info('Finished writing line-level results')
+
+        logging.info('Writing specimen-level results...')
+        
         specimen_out_dir = out_dir / 'specimen-level'
         specimen_out_dir.mkdir(exist_ok=True)
 
@@ -95,6 +100,8 @@ class ResultsWriter:
             self._write(spec_t, spec_p, spec_q, specimen_out_dir, spec_id)
 
         # self.log(self.out_dir, 'Organ_volume stats', results.input_)
+        logging.info('Finished writing specimen-level results')
+
 
     @staticmethod
     def factory(data_type):


### PR DESCRIPTION
1. common.py: added method for logging memory usage; write_array minor
fix
2. stats/standard_stats/data_loaders.py: LineData added cleanup()
method; changed the way for calculation of number of chunks to be based
on process memory
3. stats/standard_stats/lama_stats_new.py: loop 'for' replaced with loop
'while' and catch of StopIteration to clean the last Iterator LineData
item's data; minor fix for reading 'memmap' attribute from config;
4. stats/standard_stats/results_writer.py: logging added for line- and
specimen-level image writing;