### PR TITLE
still run LAMA if git commit cannot be determined

### DIFF
--- a/lama/common.py
+++ b/lama/common.py
@@ -311,10 +311,16 @@ def git_log() -> str:
     except OSError:
         # current_commit file does not exist (This would come from pip install.
         # So try using git
-        repo = git.Repo(search_parent_directories=True)
-        sha = repo.head.object.hexsha[:7]
-        msg = f'Git commit: {sha}'
-
+        try:
+            repo = git.Repo(search_parent_directories=True)
+            sha = repo.head.object.hexsha[:7]
+            msg = f'Git commit: {sha}'
+        # Kyle -if the git commit can not be determined, for example
+        # running python3 setup.py install --user installs into site packages
+        # stuffing the git commit up - you get the error below and stops LAMA
+        # from running - hence the extra try except
+        except git.exc.InvalidGitRepositoryError:
+            pass
     if not msg:
         msg = f'Cannot determine git commit'
 


### PR DESCRIPTION
If the git commit can not be determined, e.g. python3 setup.py install --user  installs into site-packages on NCI and stuffs up the git commit (the code is fine you just can't determine the commit), a git.exc.InvalidGitRepositoryError will occur.  

Therefore you need a try-except in here if you want to run on an undetermined git.